### PR TITLE
Node update part 2

### DIFF
--- a/.github/workflows/test_pr_image.yml
+++ b/.github/workflows/test_pr_image.yml
@@ -37,10 +37,10 @@ jobs:
         load: true
         tags: ${{ env.NARRATIVE_IMG_TAG }}
     -
-      name: Use Node JS 16
-      uses: actions/setup-node@v2
+      name: Use Node JS 20
+      uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 20
     -
       name: Install JS dependencies
       run: |

--- a/jupyter-pip-requirements.txt
+++ b/jupyter-pip-requirements.txt
@@ -1,3 +1,3 @@
 ipython==8.10.0
-notebook==6.4.12
+notebook==6.5.6
 ipywidgets==7.7.1

--- a/release_notes/7.1.2.md
+++ b/release_notes/7.1.2.md
@@ -1,0 +1,4 @@
+# Narrative Base Image 7.1.2
+
+## Core package updates
+node 16.x -> 20.x (latest LTS)


### PR DESCRIPTION
* update GHA to use node 20 for testing the full image (base + narrative images)
* add release notes for version 7.1.2