### PR TITLE
downgrade Python base image to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # These ARGs values are passed in via the docker build command
 ARG BUILD_DATE

--- a/release_notes/8.0.0.md
+++ b/release_notes/8.0.0.md
@@ -5,7 +5,7 @@ Base image debian version updated from bullseye to bookworm.
 
 ## Python
 ### Language version
-Python has been updated from 3.10 -> 3.12.
+Python has been updated from 3.10 -> 3.11.
 
 ### Package updates
 All python package installation now occurs in the narrative repo.


### PR DESCRIPTION
A needed dependency for the version of Jupyter Notebook we're stuck on is only compatible with 3.11